### PR TITLE
Test qe

### DIFF
--- a/irrep/__kpoint.py
+++ b/irrep/__kpoint.py
@@ -269,7 +269,7 @@ class Kpoint():
         KG=(kg+kpt).dot(RecLattice)
         npw=kg.shape[0]
         eKG=Hartree_eV*(la.norm(KG,axis=1)**2)/2
-        print (Ecut0,np.max(eKG))
+        print ('Found cutoff: {0:12.6f} eV   Largest plane wave energy in K-point {1:4d}: {2:12.6f} eV'.format(Ecut0,self.ik0,np.max(eKG)))
         assert   Ecut0*1.000000001>np.max(eKG) 
         sel=np.where(eKG<Ecut)[0]
         npw1=sel.shape[0]

--- a/irrep/__spacegroup.py
+++ b/irrep/__spacegroup.py
@@ -285,7 +285,7 @@ class SpaceGroup():
             found=False
             for i,sym2 in enumerate(table.symmetries):
                 t1=np.dot(sym2.t-t,invlattice)%1
-                t1[1-t1>1e-5]=0
+                t1[1-t1<1e-5]=0
                 if np.allclose(R,sym2.R) and np.allclose(t1,[0,0,0]):
                     ind.append(i)
                     dt.append(sym2.t-t)


### PR DESCRIPTION
Test and correct the interface for Quantum Espresso. Issues found and corrected:

- Comparison between symmetry operations found by spglib and those of tables.
- Energy levels are written in Ry in QE output files. I have converted them to eV.