### PR TITLE
Long records abinit

### DIFF
--- a/irrep/bandstructure.py
+++ b/irrep/bandstructure.py
@@ -70,9 +70,12 @@ class BandStructure:
     refUC : array, default=None
         3x3 array describing the transformation of vectors defining the 
         unit cell to the standard setting.
-    shiftUC : array
+    shiftUC : array, default=None
         Translation taking the origin of the unit cell used in the DFT 
         calculation to that of the standard setting.
+    identify_irreps : bool, default=False
+        Whether irreps should be identify after calculating traces. 
+        It is `True` if kpnames was specified in CLI.
 
     Attributes
     ----------
@@ -121,7 +124,7 @@ class BandStructure:
         spin_channel=None,
         refUC = None,
         shiftUC = None,
-        searchUC = False,
+        identify_irreps = False
     ):
         code = code.lower()
 
@@ -131,19 +134,19 @@ class BandStructure:
         
         if code == "vasp":
             self.__init_vasp(
-                fWAV, fPOS, Ecut, IBstart, IBend, kplist, spinor, EF=EF, onlysym=onlysym, refUC=refUC, shiftUC=shiftUC, searchUC=searchUC
+                fWAV, fPOS, Ecut, IBstart, IBend, kplist, spinor, EF=EF, onlysym=onlysym, refUC=refUC, shiftUC=shiftUC, identify_irreps=identify_irreps
             )
         elif code == "abinit":
             self.__init_abinit(
-                fWFK, Ecut, IBstart, IBend, kplist, EF=EF, onlysym=onlysym, refUC=refUC, shiftUC=shiftUC, searchUC=searchUC
+                fWFK, Ecut, IBstart, IBend, kplist, EF=EF, onlysym=onlysym, refUC=refUC, shiftUC=shiftUC, identify_irreps=identify_irreps
             )
         elif code == "espresso":
             self.__init_espresso(
-                prefix, Ecut, IBstart, IBend, kplist, EF=EF, onlysym=onlysym, spin_channel=spin_channel, refUC=refUC, shiftUC=shiftUC, searchUC=searchUC
+                prefix, Ecut, IBstart, IBend, kplist, EF=EF, onlysym=onlysym, spin_channel=spin_channel, refUC=refUC, shiftUC=shiftUC, identify_irreps=identify_irreps
             )
         elif code == "wannier90":
             self.__init_wannier(
-                prefix, Ecut, IBstart, IBend, kplist, EF=EF, onlysym=onlysym, refUC=refUC, shiftUC=shiftUC, searchUC=searchUC
+                prefix, Ecut, IBstart, IBend, kplist, EF=EF, onlysym=onlysym, refUC=refUC, shiftUC=shiftUC, identify_irreps=identify_irreps
             )
         else:
             raise RuntimeError("Unknown/unsupported code :{}".format(code))
@@ -161,7 +164,7 @@ class BandStructure:
         onlysym=False,
         refUC=None,
         shiftUC=None,
-        searchUC=False,
+        identify_irreps=False,
     ):
         """
         Initialization for vasp. Read data and save it in attributes.
@@ -192,12 +195,15 @@ class BandStructure:
         shiftUC : array, default=None
             Translation taking the origin of the unit cell used in the DFT 
             calculation to that of the standard setting.
+        identify_irreps : bool, default=False
+            Whether irreps should be identify after calculating traces. 
+            It is `True` if kpnames was specified in CLI.
         """
         if spinor is None:
             raise RuntimeError(
                 "spinor should be specified in the command line for VASP bandstructure"
             )
-        self.spacegroup = SpaceGroup(inPOSCAR=fPOS, spinor=spinor, refUC=refUC, shiftUC=shiftUC, searchUC=searchUC)
+        self.spacegroup = SpaceGroup(inPOSCAR=fPOS, spinor=spinor, refUC=refUC, shiftUC=shiftUC, identify_irreps=identify_irreps)
         self.spinor = spinor
         if onlysym:
             return
@@ -298,7 +304,7 @@ class BandStructure:
         onlysym=False,
         refUC=None,
         shiftUC=None,
-        searchUC=False,
+        identify_irreps = False
     ):
         """
         Initialization for abinit. Read data and store it in attributes.
@@ -325,13 +331,16 @@ class BandStructure:
         shiftUC : array, default=None
             Translation taking the origin of the unit cell used in the DFT 
             calculation to that of the standard setting.
+        identify_irreps : bool, default=False
+            Whether irreps should be identify after calculating traces. 
+            It is `True` if kpnames was specified in CLI.
         """
 
         header = AbinitHeader(WFKname)
         usepaw = header.usepaw
         self.spinor = header.spinor
         self.spacegroup = SpaceGroup(
-            cell=(header.rprimd, header.xred, header.typat), spinor=self.spinor, refUC=refUC, shiftUC=shiftUC, searchUC=searchUC
+            cell=(header.rprimd, header.xred, header.typat), spinor=self.spinor, refUC=refUC, shiftUC=shiftUC, identify_irreps=identify_irreps
         )
         if onlysym:
             return
@@ -426,7 +435,7 @@ class BandStructure:
         onlysym=False,
         refUC=None,
         shiftUC=None,
-        searchUC=False,
+        identify_irreps = False
     ):
         """
         Initialization for wannier90. Read data and store it in attibutes.
@@ -454,6 +463,9 @@ class BandStructure:
         shiftUC : array, default=None
             Translation taking the origin of the unit cell used in the DFT 
             calculation to that of the standard setting.
+        identify_irreps : bool, default=False
+            Whether irreps should be identify after calculating traces. 
+            It is `True` if kpnames was specified in CLI.
         """
         if Ecut is None:
             raise RuntimeError("Ecut mandatory for Wannier90")
@@ -678,7 +690,7 @@ class BandStructure:
         )
 
         self.spacegroup = SpaceGroup(
-            cell=(self.Lattice, xred, typat), spinor=self.spinor, refUC=refUC, shiftUC=shiftUC, searchUC=searchUC
+            cell=(self.Lattice, xred, typat), spinor=self.spinor, refUC=refUC, shiftUC=shiftUC, identify_irreps=identify_irreps
         )
         if onlysym:
             return
@@ -741,7 +753,7 @@ class BandStructure:
         spin_channel=None,
         refUC=None,
         shiftUC=None,
-        searchUC=False,
+        identify_irreps = False
     ):
         """
         Initialization for Quantum Espresso. Read data and store in attributes.
@@ -771,6 +783,9 @@ class BandStructure:
         shiftUC : array, default=None
             Translation taking the origin of the unit cell used in the DFT 
             calculation to that of the standard setting.
+        identify_irreps : bool, default=False
+            Whether irreps should be identify after calculating traces. 
+            It is `True` if kpnames was specified in CLI.
         """
         import xml.etree.ElementTree as ET
 
@@ -805,7 +820,7 @@ class BandStructure:
         xred = (np.array(xcart, dtype=float) * BOHR).dot(np.linalg.inv(self.Lattice))
         #        print ("xred=",xred)
         self.spacegroup = SpaceGroup(
-            cell=(self.Lattice, xred, typat), spinor=self.spinor, refUC=refUC, shiftUC=shiftUC, searchUC=searchUC
+            cell=(self.Lattice, xred, typat), spinor=self.spinor, refUC=refUC, shiftUC=shiftUC, identify_irreps=identify_irreps
         )
         if onlysym:
             return
@@ -1011,6 +1026,9 @@ class BandStructure:
                     efermi=self.efermi,
                     plotFile=pFile,
                     kpl=kpl,
+                    symmetries_tables=self.spacegroup.symmetries_tables,
+                    refUC=self.spacegroup.refUC,
+                    shiftUC=self.spacegroup.shiftUC
                 )
                 kdata["kp in line"] = kpl
                 json_data["k-points" ].append(kdata)

--- a/irrep/cli.py
+++ b/irrep/cli.py
@@ -276,11 +276,14 @@ def cli(
     
     # Warning about kpnames
     if kpnames is None:
+        identify_irreps = False
         print(("Warning: kpnames not specified. Only traces of "
                "symmetry operations will be calculated. Remember that "
                "kpnames must be specified to identify irreps"
                )
               )
+    else:
+        identify_irreps = True
 
     # parse input arguments into lists if supplied
     if symmetries:
@@ -315,7 +318,7 @@ def cli(
         onlysym=onlysym,
         refUC = refuc,
         shiftUC = shiftuc,
-        searchUC = True,
+        identify_irreps = identify_irreps,
     )
 
     json_data ["spacegroup"] = bandstr.spacegroup.show(symmetries=symmetries)

--- a/irrep/kpoint.py
+++ b/irrep/kpoint.py
@@ -684,7 +684,7 @@ class Kpoint:
         print("reading k-point", ik)
         # we need to skip lines in fWFK until we reach the lines of ik
         while flag < ik:
-            record = record_abinit(fWFK, "3i4")  # [0]
+            record = record_abinit(fWFK, "i4")  # [0]
             npw, nspinor_loc, nband_loc = record
             kg = record_abinit(fWFK, "({npw},3)i4".format(npw=npw))  # [0]
             eigen, occ = fWFK.read_record(

--- a/irrep/kpoint.py
+++ b/irrep/kpoint.py
@@ -1100,15 +1100,15 @@ class Kpoint:
 
         # Transfer traces in calculational cell to refUC
         char_refUC = char.copy()
+        k_refUC = np.dot(refUC.T, self.K)
         if (not np.allclose(refUC, np.eye(3, dtype=float)) or
             not np.allclose(shiftUC, np.zeros(3, dtype=float))):
             # Calculational and reference cells are not identical
             for i,ind in enumerate(sym):
                 dt = (symmetries_tables[ind-1].t 
                       - sym[ind].translation_refUC(refUC, shiftUC))
-                k = np.round(refUC.dot(self.K), 5)
                 char_refUC[:,i] *= (sym[ind].sign 
-                                     * np.exp(-2j*np.pi*dt.dot(k)))
+                                     * np.exp(-2j*np.pi*dt.dot(k_refUC)))
 
         json_data["characters_refUC"] = char_refUC
         if np.allclose(char, char_refUC, rtol=0.0, atol=1e-4):
@@ -1130,11 +1130,11 @@ class Kpoint:
 
         # Header of the block
         print(("\n\n k-point {0:3d} : {1} (in DFT cell)\n"
-               "               {2} (in convenctional cell)\n\n"
+               "               {2} (after cell trasformation)\n\n"
                " number of states : {3}\n"
                .format(self.ik0,
                        np.round(self.K, 5),
-                       np.round(np.dot(refUC.T, self.K),5),
+                       np.round(k_refUC,5),
                        self.Nband
                        )
               ))

--- a/irrep/kpoint.py
+++ b/irrep/kpoint.py
@@ -681,21 +681,20 @@ class Kpoint:
         """
         assert not (kpt is None)
         self.K = kpt
+        nspinor = 2 if self.spinor else 1
         print("reading k-point", ik)
         # we need to skip lines in fWFK until we reach the lines of ik
         while flag < ik:
             record = record_abinit(fWFK, "i4")  # [0]
             npw, nspinor_loc, nband_loc = record
-            kg = record_abinit(fWFK, "({npw},3)i4".format(npw=npw))  # [0]
-            eigen, occ = fWFK.read_record(
-                "{nband}f8,{nband}f8".format(nband=nband_loc)
-            )[0]
-            nspinor = 2 if self.spinor else 1
+            kg = record_abinit(fWFK, "i4").reshape(npw, 3)
+            record = record_abinit(fWFK, "f8")
+            eigen, occ = record[:nband_loc], record[nband_loc:]
             CG = np.zeros((IBend - IBstart, npw * nspinor), dtype=complex)
             for iband in range(nband_loc):
-                cg_tmp = record_abinit(fWFK, "{0}f8".format(2 * npw * nspinor))  # [0]
+                record = record_abinit(fWFK, "f8")
                 if iband >= IBstart and iband < IBend:
-                    CG[iband - IBstart] = cg_tmp[0::2] + 1.0j * cg_tmp[1::2]
+                    CG[iband - IBstart] = record[0::2] + 1.0j * record[1::2]
             flag += 1
 
         # now, we have kept in npw,nspinor_loc,naband_loc,eigen,occ,cg_tmp the

--- a/irrep/readfiles.py
+++ b/irrep/readfiles.py
@@ -136,9 +136,10 @@ class AbinitHeader():
         stdout.flush()
         codsvn = record[0][0].decode('ascii')
         headform, fform = record[0][1]
-        defversion = '8.6.3 '  # TODO: add list of tested versions
-        if not (codsvn == defversion):
-            print(("WARNING, the version {0} of abinit is not {1}"
+        defversion = ['8.6.3', '9.6.2', '8.4.4', '8.10.3']
+        if codsvn not in defversion:
+            print(("WARNING, the version {0} of abinit is not in {1} "
+                   "and may not be fully tested"
                    .format(codsvn, defversion))
                   )
         if headform < 80:

--- a/irrep/readfiles.py
+++ b/irrep/readfiles.py
@@ -20,6 +20,7 @@ import numpy as np
 import scipy
 from scipy.io import FortranFile as FF
 from sys import stdout
+from .utility import FortranFileR
 
 
 class WAVECARFILE:
@@ -115,8 +116,9 @@ class AbinitHeader():
 
     def __init__(self, fname):
 
-        self.fWFK = FF(fname, "r")
-        fWFK = self.fWFK
+        #self.fWFK = FF(fname, "r")
+        fWFK = FortranFileR(fname)  # TODO: check first w/o fortio, as it's faster
+        self.fWFK = fWFK
         record = fWFK.read_record('a6,2i4')
 #    print (record)
         stdout.flush()

--- a/irrep/readfiles.py
+++ b/irrep/readfiles.py
@@ -119,12 +119,12 @@ class AbinitHeader():
         #fWFK = FF(fname, "r")
         fWFK = FFR(fname)  # TODO: check first w/o fortio, as it's faster
         self.fWFK = fWFK
-        record = fWFK.read_record('a6,2i4')
-#    print (record)
+        # write(unit=header) codvsn,headform,fform
+        record = record_abinit(fWFK, 'a6,2i4')
         stdout.flush()
         codsvn = record[0][0].decode('ascii')
         headform, fform = record[0][1]
-        defversion = '8.6.3 '
+        defversion = '8.6.3 '  # TODO: add list of tested versions
         if not (codsvn == defversion):
             print(
                 "WARNING, the version {0} of abinit is not {1}".format(
@@ -133,8 +133,7 @@ class AbinitHeader():
             raise ValueError(
                 "Head form {0}<80 is not supported".format(headform))
 
-        record = fWFK.read_record('18i4,19f8,4i4')[0]
-        # write(unit=header) codvsn,headform,fform
+        record = record_abinit(fWFK, '18i4,19f8,4i4')[0]
         # write(unit=header) bantot,date,intxc,ixc,natom,ngfft(1:3),&
         # & nkpt,nspden,nspinor,nsppol,nsym,npsp,ntypat,occopt,pertcase,usepaw,&
         # & ecut,ecutdg,ecutsm,ecut_eff,qptn(1:3),rprimd(1:3,1:3),stmbias,tphysel,tsmear,usewvl,
@@ -161,8 +160,9 @@ class AbinitHeader():
         nshiftk_orig = record[2][1]
         nshiftk = record[2][2]
         #print (bandtot,natom,nkpt,nsym,npsp,nsppol,ntypat)
-        record = fWFK.read_record(
-            '{nkpt}i4,{n2}i4,{nkpt}i4,{npsp}i4,{nsym}i4,({nsym},3,3)i4,{natom}i4,({nkpt},3)f8,{bandtot}f8,({nsym},3)f8,{ntypat}f8,{nkpt}f8'.format(
+        record = record_abinit(
+                    fWFK,
+                    '{nkpt}i4,{n2}i4,{nkpt}i4,{npsp}i4,{nsym}i4,({nsym},3,3)i4,{natom}i4,({nkpt},3)f8,{bandtot}f8,({nsym},3)f8,{ntypat}f8,{nkpt}f8'.format(
                 nkpt=self.nkpt,
                 n2=self.nkpt *
                 nsppol,
@@ -189,16 +189,18 @@ class AbinitHeader():
         assert(np.sum(self.nband) == bandtot)
         #print (kpt,nband)
 
-        record = fWFK.read_record(
-            'f8,({natom},3)f8,f8,f8,{ntypat}f8'.format(
+        record = record_abinit(
+                    fWFK,
+                    'f8,({natom},3)f8,f8,f8,{ntypat}f8'.format(
                 natom=self.natom, ntypat=ntypat))[0]
         self.xred = record[1]
         self.efermi = record[3]
         # write(unit,err=10, iomsg=errmsg) hdr%residm, hdr%xred(:,:), hdr%etot, hdr%fermie, hdr%amu(:)
         #print (record)
 
-        record = fWFK.read_record(
-            "i4,i4,f8,f8,i4,(3,3)i4,(3,3)i4,({nshiftkorig},3)f8,({nshiftk},3)f8".format(
+        record = record_abinit(
+                    fWFK,
+                    "i4,i4,f8,f8,i4,(3,3)i4,(3,3)i4,({nshiftkorig},3)f8,({nshiftk},3)f8".format(
                 nshiftkorig=nshiftk_orig, nshiftk=nshiftk))[0]
         #record=fWFK.read_record("i4,i4,f8,f8,i4,i4,(3,3)f8,5f8,i4".format(nshiftkorig=nshiftk_orig,nshiftk=nshiftk) )[0]
         ##record=fWFK.read_record("i4,i4,f8,f8,i4,9i4,9i4,6f8".format(nshiftkorig=nshiftk_orig,nshiftk=nshiftk) )[0]
@@ -208,7 +210,7 @@ class AbinitHeader():
         #print (record)
 
         for ipsp in range(npsp):
-            record = fWFK.read_record("a132,f8,f8,5i4,a32")[0]
+            record = record_abinit(fWFK, "a132,f8,f8,5i4,a32")[0]
         #   read(unit, err=10, iomsg=errmsg) &
         # &   hdr%title(ipsp), hdr%znuclpsp(ipsp), hdr%zionpsp(ipsp), hdr%pspso(ipsp), hdr%pspdat(ipsp), &
         # &   hdr%pspcod(ipsp), hdr%pspxc(ipsp), hdr%lmn_size(ipsp), hdr%md5_pseudos(ipsp)

--- a/irrep/readfiles.py
+++ b/irrep/readfiles.py
@@ -112,115 +112,140 @@ class AbinitHeader():
         Each row contains the direct coordinates of an ion's position. 
     efermi : float
         Fermi-level.
+
+    Notes
+    -----
+    Abinit's routines that write the header can be found
+    `here <https://docs.abinit.org/guide/abinit/#5>`_ or in the file
+    `src/56_io_mpi/m_hdr.f90`.
     """
 
     def __init__(self, fname):
 
         #fWFK = FF(fname, "r")
-        fWFK = FFR(fname)  # TODO: check first w/o fortio, as it's faster
+        fWFK = FFR(fname)
         self.fWFK = fWFK
-        # write(unit=header) codvsn,headform,fform
+
+        # 1st record
+            # write(unit=header) codvsn,headform,fform
         record = record_abinit(fWFK, 'a6,2i4')
         stdout.flush()
         codsvn = record[0][0].decode('ascii')
         headform, fform = record[0][1]
         defversion = '8.6.3 '  # TODO: add list of tested versions
         if not (codsvn == defversion):
-            print(
-                "WARNING, the version {0} of abinit is not {1}".format(
-                    codsvn, defversion))
+            print(("WARNING, the version {0} of abinit is not {1}"
+                   .format(codsvn, defversion))
+                  )
         if headform < 80:
             raise ValueError(
-                "Head form {0}<80 is not supported".format(headform))
+                "Head form {0}<80 is not supported".format(headform)
+                )
 
+        # 2nd record
+            # write(unit=header) bantot,date,intxc,ixc,natom,ngfft(1:3), nkpt,&
+            # & nspden,nspinor,nsppol,nsym,npsp,ntypat,occopt,pertcase,usepaw,&
+            # & ecut,ecutdg,ecutsm,ecut_eff,qptn(1:3),rprimd(1:3,1:3),stmbias,&
+            # & tphysel,tsmear,usewvl, hdr%nshiftk_orig, hdr%nshiftk, hdr%mband
         record = record_abinit(fWFK, '18i4,19f8,4i4')[0]
-        # write(unit=header) bantot,date,intxc,ixc,natom,ngfft(1:3),&
-        # & nkpt,nspden,nspinor,nsppol,nsym,npsp,ntypat,occopt,pertcase,usepaw,&
-        # & ecut,ecutdg,ecutsm,ecut_eff,qptn(1:3),rprimd(1:3,1:3),stmbias,tphysel,tsmear,usewvl,
-        #hdr%nshiftk_orig, hdr%nshiftk, hdr%mband
-#    print (record)
-        self.rprimd = record[1][7:16].reshape((3, 3))
-#    print (self.rprimd)
-        self.ecut = record[1][0] * Hartree_eV
-        print("ecut={0} eV".format(self.ecut))
         stdout.flush()
-        bandtot, self.natom, self.nkpt, nsym, npsp, nsppol, ntypat, self.usepaw, nspinor = np.array(
-            record[0])[[0, 4, 8, 12, 13, 11, 14, 17, 10]]
+        (bandtot,
+         self.natom,
+         self.nkpt,
+         nsym,
+         npsp,
+         nsppol,
+         ntypat,
+         self.usepaw,
+         nspinor) = np.array(record[0])[[0, 4, 8, 12, 13, 11, 14, 17, 10]]
+        self.rprimd = record[1][7:16].reshape((3, 3))
+        self.ecut = record[1][0] * Hartree_eV
+        nshiftk_orig = record[2][1]
+        nshiftk = record[2][2]
+
+        # Check spin-polarization and if wave functions are spinors
         if nsppol != 1:
             raise RuntimeError(
-                "Only nsppol=1 is supported. found {0}".format(nsppol))
+                "Only nsppol=1 is supported. found {0}".format(nsppol)
+                )
         if nspinor == 2:
             self.spinor = True
         elif nspinor == 1:
             self.spinor = False
         else:
             raise RuntimeError(
-                "Unexpected value nspinor = {0}".format(nspinor))
-        #if usepaw==1: raise ValueError("usepaw==1 not implemented")
-        nshiftk_orig = record[2][1]
-        nshiftk = record[2][2]
-        #print (bandtot,natom,nkpt,nsym,npsp,nsppol,ntypat)
-        record = record_abinit(
-                    fWFK,
-                    '{nkpt}i4,{n2}i4,{nkpt}i4,{npsp}i4,{nsym}i4,({nsym},3,3)i4,{natom}i4,({nkpt},3)f8,{bandtot}f8,({nsym},3)f8,{ntypat}f8,{nkpt}f8'.format(
-                nkpt=self.nkpt,
-                n2=self.nkpt *
-                nsppol,
-                npsp=npsp,
-                nsym=nsym,
-                natom=self.natom,
-                bandtot=bandtot,
-                ntypat=ntypat))[0]
-        #print (record)
-        # write(unit=header) istwfk(1:nkpt),nband(1:nkpt*nsppol),&
-        # & npwarr(1:nkpt),so_psp(1:npsp),symafm(1:nsym),symrel(1:3,1:3,1:nsym),typat(1:natom),&
-        # & kpt(1:3,1:nkpt),occ(1:bantot),tnons(1:3,1:nsym),znucltypat(1:ntypat),wtk(1:nkpt)
-#    wtk=record[11]
+                "Unexpected value nspinor = {0}".format(nspinor)
+                )
+
+        # 3rd record
+            # write(unit=header) istwfk(1:nkpt),nband(1:nkpt*nsppol),&
+            # & npwarr(1:nkpt),so_psp(1:npsp),symafm(1:nsym), &
+            # & symrel(1:3,1:3,1:nsym),typat(1:natom), kpt(1:3,1:nkpt), &
+            # & occ(1:bantot),tnons(1:3,1:nsym),znucltypat(1:ntypat), &
+            # & wtk(1:nkpt)
+        fmt = ('{nkpt}i4,{n2}i4,{nkpt}i4,{npsp}i4,{nsym}i4,({nsym},3,3)i4,'
+               '{natom}i4,({nkpt},3)f8,{bandtot}f8,({nsym},3)f8,{ntypat}f8,'
+               '{nkpt}f8'
+               .format(
+                    nkpt=self.nkpt,
+                    n2=self.nkpt *
+                    nsppol,
+                    npsp=npsp,
+                    nsym=nsym,
+                    natom=self.natom,
+                    bandtot=bandtot,
+                    ntypat=ntypat)
+               )
+        record = record_abinit(fWFK, fmt)[0]
         self.typat = record[6]
         self.kpt = record[7]
         self.nband = record[1]
         self.npwarr, self.istwfk = record[2], record[0]
         self.__fix_arrays() # fix istwfk, npwarr and nband when nkpt==1
 
-        # checks 
+        # Check that istwfk was 1 and consistency of number of bands
         if self.istwfk != {1}:
-            raise ValueError(
-                "istwfk should be 1 for all kpoints. found {0}".format(self.istwfk))
-        assert(np.sum(self.nband) == bandtot)
-        #print (kpt,nband)
+            raise ValueError(("istwfk should be 1 for all kpoints. Found {0}"
+                              .format(self.istwfk))
+                             )
+        assert np.sum(self.nband) == bandtot, "Probably a bug in Abinit"
 
+        # 4th record
+            # write(unit,err=10, iomsg=errmsg) hdr%residm, hdr%xred(:,:), &
+            # & hdr%etot, hdr%fermie, hdr%amu(:)
         record = record_abinit(
                     fWFK,
-                    'f8,({natom},3)f8,f8,f8,{ntypat}f8'.format(
-                natom=self.natom, ntypat=ntypat))[0]
+                    'f8,({natom},3)f8,f8,f8,{ntypat}f8'.format(natom=self.natom,
+                                                               ntypat=ntypat
+                                                               )
+                    )[0]
         self.xred = record[1]
         self.efermi = record[3]
-        # write(unit,err=10, iomsg=errmsg) hdr%residm, hdr%xred(:,:), hdr%etot, hdr%fermie, hdr%amu(:)
-        #print (record)
 
-        record = record_abinit(
-                    fWFK,
-                    "i4,i4,f8,f8,i4,(3,3)i4,(3,3)i4,({nshiftkorig},3)f8,({nshiftk},3)f8".format(
-                nshiftkorig=nshiftk_orig, nshiftk=nshiftk))[0]
-        #record=fWFK.read_record("i4,i4,f8,f8,i4,i4,(3,3)f8,5f8,i4".format(nshiftkorig=nshiftk_orig,nshiftk=nshiftk) )[0]
-        ##record=fWFK.read_record("i4,i4,f8,f8,i4,9i4,9i4,6f8".format(nshiftkorig=nshiftk_orig,nshiftk=nshiftk) )[0]
-        # write(unit,err=10, iomsg=errmsg) &
-        #   hdr%kptopt, hdr%pawcpxocc, hdr%nelect, hdr%charge, hdr%icoulomb,&
-        #   hdr%kptrlatt,hdr%kptrlatt_orig, hdr%shiftk_orig(:,1:hdr%nshiftk_orig),hdr%shiftk(:,1:hdr%nshiftk)
-        #print (record)
+        # 5th record: skip it
+            # write(unit,err=10, iomsg=errmsg) &
+            # & hdr%kptopt, hdr%pawcpxocc, hdr%nelect, hdr%charge, &
+            # & hdr%icoulomb, hdr%kptrlatt,hdr%kptrlatt_orig, &
+            # & hdr%shiftk_orig(:,1:hdr%nshiftk_orig), &
+            # & hdr%shiftk(:,1:hdr%nshiftk)
+        fmt = ('i4,i4,f8,f8,i4,(3,3)i4,(3,3)i4,({nshiftkorig},3)f8,'
+               '({nshiftk},3)f8'
+               .format(nshiftkorig=nshiftk_orig, nshiftk=nshiftk)
+               )
+        record = record_abinit(fWFK,fmt)[0]
 
+        # 6th record: skip it
+            # read(unit, err=10, iomsg=errmsg) hdr%title(ipsp), &
+            # & hdr%znuclpsp(ipsp), hdr%zionpsp(ipsp), hdr%pspso(ipsp), &
+            # & hdr%pspdat(ipsp), hdr%pspcod(ipsp), hdr%pspxc(ipsp), &
+            # & hdr%lmn_size(ipsp), hdr%md5_pseudos(ipsp)
         for ipsp in range(npsp):
             record = record_abinit(fWFK, "a132,f8,f8,5i4,a32")[0]
-        #   read(unit, err=10, iomsg=errmsg) &
-        # &   hdr%title(ipsp), hdr%znuclpsp(ipsp), hdr%zionpsp(ipsp), hdr%pspso(ipsp), hdr%pspdat(ipsp), &
-        # &   hdr%pspcod(ipsp), hdr%pspxc(ipsp), hdr%lmn_size(ipsp), hdr%md5_pseudos(ipsp)
-        #    print (record)
 
+        # 7th record: additional records if usepaw=1
         if self.usepaw == 1:
             record = fWFK.read_record('i4')
-#        print(record)
             record = fWFK.read_record('f8')
-#        print(record)
 
     def __fix_arrays(self):
         '''when nkpt=1, some integers must be converted to iterables, to avoid problems with indices'''

--- a/irrep/readfiles.py
+++ b/irrep/readfiles.py
@@ -20,7 +20,7 @@ import numpy as np
 import scipy
 from scipy.io import FortranFile as FF
 from sys import stdout
-from .utility import FortranFileR
+from .utility import FortranFileR as FFR
 
 
 class WAVECARFILE:
@@ -116,8 +116,8 @@ class AbinitHeader():
 
     def __init__(self, fname):
 
-        #self.fWFK = FF(fname, "r")
-        fWFK = FortranFileR(fname)  # TODO: check first w/o fortio, as it's faster
+        #fWFK = FF(fname, "r")
+        fWFK = FFR(fname)  # TODO: check first w/o fortio, as it's faster
         self.fWFK = fWFK
         record = fWFK.read_record('a6,2i4')
 #    print (record)

--- a/irrep/utility.py
+++ b/irrep/utility.py
@@ -23,7 +23,16 @@ import fortio
 BOHR = constants.physical_constants['Bohr radius'][0] / constants.angstrom
 
 
-class FortranFileR(fortio.FortranFile): # TODO: add docstring
+class FortranFileR(fortio.FortranFile):
+    '''
+    Class that implements `syrte/fortio` package to parse long records
+    in Abinit WFK file.
+
+    Parameters
+    ----------
+    filename : str
+        Path to the WFK file.
+    '''
 
     def __init__(self, filename):
 

--- a/irrep/utility.py
+++ b/irrep/utility.py
@@ -18,9 +18,35 @@
 
 import numpy as np
 from scipy import constants
+import fortio
 
 BOHR = constants.physical_constants['Bohr radius'][0] / constants.angstrom
 
+
+class FortranFileR(fortio.FortranFile): # TODO: add docstring
+
+    def __init__(self, filename):
+
+        print("Using fortio to read")
+
+        try:  # assuming there are not subrecords
+            super().__init__(filename,
+			     mode='r',
+			     header_dtype='uint32',
+			     auto_endian=True,
+			     check_file=True
+			     )
+            print("Long records not found in ", filename)
+        except ValueError:  # there are subrecords, allow negative markers
+            print(("File '{}' contains subrecords - using header_dtype='int32'"
+		   .format(filename)
+		  ))
+            super().__init__(filename,
+			     mode='r',
+			     header_dtype='int32',
+			     auto_endian=True,
+			     check_file=True
+			     )
 
 def str2list(string):
     """

--- a/setup.py
+++ b/setup.py
@@ -22,6 +22,7 @@ setuptools.setup(
         "monty",
         "ruamel.yaml",
         "irreptables",
+        "fortio"
     ],
     include_package_data=False,
     url="https://github.com/stepan-tsirkin/irrep",


### PR DESCRIPTION
This PR implements the following points:

- The package `syrte/fortio` to deal with long records in Abinit's WFK file.
- Make `IrRep` compatible with Abinit > 9.0.0, while preserving the compatibility with Abinit 8.x.x. I realized that they changed the header of the WFK file. 
- The lines that parse records with multiple elements (strings, int, float,...) are now implemented in 2 steps:
    1- Parse through `record_abinit(fWFK, 'f8')` rather than `record_abinit(fWFK, '3f8')` (this is just an example).
    2- Split the record to save it into variables through `x, y, z  = record[0], record[1],...`
    I think that way the parsing may be more stable, because it does not require knowing how may elements have to be parsed, only their types. If I'm not wrong, it is implemented that way in `WannierBerri`.
- Clean up the code of the function `__init_abinit` in `kpoint.py` and the class `AbinitHeader` in `readfiles.py`. It is also made more PEP8 friendly and some error and warning messages have been made more clear.
- Fix a bug in the call to `Kpoint.write_characters` in `bandstructure.py`: when `kpnames` was not specified in the CLI, `refUC=identity` and `shiftUC=0,0,0` were always passed to `Kpoint.write_characters`.
- Modify the response to a fail in the matching of symmetries in both unit cells: until now, they **must always** match. This means that the transformation could only be to the cell of the tables. From now on, the check will still be implemented always, but
    1- It must be successful when we want to identify the irreps from the traces (`kpnames` set in CLI).
    2- It is sure that they will match if the user does not specify a transformation in the CLI, because `refUC` and `shiftUC` will be calculated automatically to satisfy the match.
    3- A warning will be raised and the flow will continue if the user specified in the CLI a transformation that does not match the symmetries in both cells. 
In this way, `IrRep` can be used to calculate the traces in **any unit cell setting**, not only for the DFT and conventional (tables) cell. In other words, if we want the traces in a cell that is not the conventional, we don't have to run a new DFT calculation with the cell we are interested in; it's enough to give `refUC` and `shiftUC` to that cell we want.
- Update the list of versions of Abinit for which `IrRep` has been tested.