### PR TITLE
fix bug when printing refUC and lattice vectors (issue #50 by xuey06)…

### DIFF
--- a/irrep/spacegroup.py
+++ b/irrep/spacegroup.py
@@ -685,16 +685,18 @@ class SpaceGroup():
                 pass
 
         # Print transformation and basis vectors in both settings
+        refUC_print = self.refUC.T  # print following convention in paper
         print("\nThe transformation to the convenctional cell is given "
               + "by:\n"
-              + "        | {} |\n".format("".join(["{:8.4f}".format(el) for el in self.refUC[0]]))
-              + "refUC = | {} |    shiftUC = {}\n".format("".join(["{:8.4f}".format(el) for el in self.refUC[1]]), np.round(self.shiftUC, 5))
-              + "        | {} |\n".format("".join(["{:8.4f}".format(el) for el in self.refUC[2]]))
+              + "        | {} |\n".format("".join(["{:8.4f}".format(el) for el in refUC_print[0]]))
+              + "refUC = | {} |    shiftUC = {}\n".format("".join(["{:8.4f}".format(el) for el in refUC_print[1]]), np.round(self.shiftUC, 5))
+              + "        | {} |\n".format("".join(["{:8.4f}".format(el) for el in refUC_print[2]]))
               )
         print("Lattice vectors of DFT (a) and reference (c) cells:")
+        Lattice_conv = self.refUC.T.dot(self.Lattice)
         for i in range(3):
             l_str = "a({:1d})=[{} ]".format(i, "".join("{:8.4f}".format(x) for x in self.Lattice[i]))
-            r_str = "c({:1d})=[{} ]".format(i, "".join("{:8.4f}".format(x) for x in self.Lattice.dot(self.refUC.T)[i]))
+            r_str = "c({:1d})=[{} ]".format(i, "".join("{:8.4f}".format(x) for x in Lattice_conv[i]))
             print("    ".join((l_str,r_str)))
 
     def show(self, symmetries=None):


### PR DESCRIPTION
Print the matrix `refUC` and basis vectors of primitive and conventional cell following Eq. (6) in the [article of IrRep](https://www.sciencedirect.com/science/article/pii/S0010465521003386)