### PR TITLE
Add `kset` property for `IrrepTable` class

### DIFF
--- a/irreptables/__init__.py
+++ b/irreptables/__init__.py
@@ -361,10 +361,12 @@ class IrrepTable:
         logger.debug("symmetries are:\n" + "\n".join(s.str() for s in self.symmetries))
 
         self.irreps = []
+        self.kset   = []
         while len(lines) > 0:
             l = lines.pop().strip()
             try:
                 kp = KPoint(line=l)
+                self.kset.append(kp)
                 logger.debug("kpoint successfully read:", kp.str())
             except Exception as err:
                 logger.debug("error while reading k-point <{0}>".format(l), err)


### PR DESCRIPTION
Thank you for your fantastic work!

I utilize `irrep` as a library to obtain high symmetry points and their irreducible representations. But I discovered that there are little group operations and irreducible representation stored in `irreptable` class, but missing information which high symmetry point it belongs.

So I add `kset` property in `irreptable` class to store such information. This modification has no effect on other parts of the program.