### PR TITLE
Error message suggests shiftUC and refUC

### DIFF
--- a/irrep/spacegroup.py
+++ b/irrep/spacegroup.py
@@ -949,7 +949,8 @@ class SpaceGroup():
                             suggestT += [T]
                         # else... check next symmetry
                         U = self.symmetries[isym].rotation @ self.refUC
-                        T = self.symmetries[isym].translation + self.shiftUC
+                        T = self.symmetries[isym].translation 
+                        T += np.linalg.inv(self.symmetries[isym].rotation).dot(self.shiftUC)
                         k1 = np.round(np.linalg.inv(U.T).dot(irr.k), 5) % 1
                     # prints Error and Report
                     error = "the kpoint {0} does not correspond to the point {1} ({2} in refUC / {3} in primUC) in the table".format(
@@ -959,13 +960,12 @@ class SpaceGroup():
                             irr.k,
                             3),
                         k1)
-                    report = '''
-                    
-The kpoint in the tables might be related to the given one by a symmetry operation.
+                    report  = "\n\n"
+                    report += "The kpoint in the tables might be related to the given one by a symmetry operation."
+                    report += "\n\n"
+                    report += "Try running again with one of these refUC / shiftUC parameters:"
+                    report += "\n\n"
 
-Try running again with one of these refUC / shiftUC parameters:
-
-'''
                     iut = 0
                     for U,T in zip(suggestU, suggestT):
                         iut += 1


### PR DESCRIPTION
Related to issue #63 

if kname is informed, but kpoint does not match the ones on the tables, it could be because the correct k point is related to the informed one by a spacegroup  operation.

The new code searches for possible refUC and shiftUC to fix this discrepancy and presents the alternatives as a report added to the RuntimeError.

For instance, for graphene the tables contain the K point, but the DFT could be using K'. The original code can transform between equivalent K points, but it can't transform from K to K'. In this PR, we add a suggestion of refUC  and shiftUC that applies this kind of transformation.

Similarly, still in graphene, there are three inequivalent M points. Or in rock-salt materials, there are four inequivalent L points. And so on. These points are inequivalent, because they are not related by a reciprocal vector translation. But they are related by a spacegroup operation. So we loop over the space group operations to search for refUC and shiftUC candidates to inform the user.